### PR TITLE
Depends on test-unit gem explicitly

### DIFF
--- a/fluent-plugin-consul.gemspec
+++ b/fluent-plugin-consul.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", "~> 3.2"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency 'diplomat', '~> 0.2.1'
 end

--- a/test/test_out_consul.rb
+++ b/test/test_out_consul.rb
@@ -1,7 +1,7 @@
 require 'fluent/test'
 require 'fluent/plugin/out_consul'
 
-class TestConsulOutput < MiniTest::Unit::TestCase
+class TestConsulOutput < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
   end


### PR DESCRIPTION
Current Ruby world, minitest,  which had been included since Ruby 2.1, is not included any more.
Instead, we should use and depend test-unit or minitest explicitly.