### PR TITLE
Migrate to use v1 API

### DIFF
--- a/fluent-plugin-consul.gemspec
+++ b/fluent-plugin-consul.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", "~> 3.2"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency 'diplomat', '~> 0.2.1'
 end

--- a/lib/fluent/plugin/out_consul.rb
+++ b/lib/fluent/plugin/out_consul.rb
@@ -1,6 +1,9 @@
-module Fluent
+require 'diplomat'
+require 'fluent/plugin/output'
 
-  class ConsulOutput < Fluent::BufferedOutput
+module Fluent::Plugin
+
+  class ConsulOutput < Fluent::Output
     Fluent::Plugin.register_output('consul', self)
 
     config_param :consul_uri, :string, :default => 'http://localhost:8500'
@@ -8,7 +11,6 @@ module Fluent
 
     def initialize
       super
-      require 'diplomat'
     end
 
     def configure(conf)
@@ -28,6 +30,10 @@ module Fluent
           ::Diplomat.put(@kv_prefix + kv[:key].to_s, kv[:value].to_s)
         end
       end
+    end
+
+    def formatted_to_msgpack_binary?
+      true
     end
 
     def consul_kvs_fmt(data)

--- a/test/test_out_consul.rb
+++ b/test/test_out_consul.rb
@@ -1,7 +1,7 @@
 require 'fluent/test'
 require 'fluent/plugin/out_consul'
 
-class TestConsulOutput < MiniTest::Unit::TestCase
+class TestConsulOutput < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
   end

--- a/test/test_out_consul.rb
+++ b/test/test_out_consul.rb
@@ -1,4 +1,5 @@
 require 'fluent/test'
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_consul'
 
 class TestConsulOutput < Test::Unit::TestCase
@@ -12,7 +13,7 @@ class TestConsulOutput < Test::Unit::TestCase
   '
 
   def create_driver(conf = CONFIG)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::ConsulOutput) do
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::ConsulOutput) do
       def write(chunk)
         chunk.read
       end


### PR DESCRIPTION
Please review after merging  #1.

---

Fluentd v1 provides brand new API which can handle multiprocessing with workers, runtime buffered/non-buffered switching, and improves chunk handling.